### PR TITLE
Fix broken dipoleWeight validation api_validation_layer.cpp

### DIFF
--- a/core/src/core/api_validation_layer.cpp
+++ b/core/src/core/api_validation_layer.cpp
@@ -806,7 +806,7 @@ std::string to_string(T* value)
 #define VALIDATE_IPLDirectivity(value) { \
     VALIDATE_POINTER(value); \
     if (value) { \
-        VALIDATE(IPLfloat32, value->dipoleWeight, (0.0f <= value->dipoleWeight && 1.0f <= value->dipoleWeight)); \
+        VALIDATE(IPLfloat32, value->dipoleWeight, (0.0f <= value->dipoleWeight && value->dipoleWeight <= 1.0f)); \
         VALIDATE(IPLfloat32, value->dipolePower, (value->dipolePower >= 0.0f)); \
     } \
 }


### PR DESCRIPTION
as is:

```
(0.0f <= value->dipoleWeight && 1.0f <= value->dipoleWeight) 
``` 

will always return false. This is because value->dipoleWeight can't simultaneously be greater than or equal to 0.0f and less than 1.0f. This fixes that bug, enabling warning-free use of source directivity again.